### PR TITLE
Align header layout with main content

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,8 +48,8 @@ const Header = () => {
       </header>
 
       {/* Header Stripe */}
-      <div className="bg-dostyq-header-stripe">
-        <div className="mx-auto h-1.5 w-full max-w-7xl px-4 sm:px-6 lg:px-8" />
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="h-1.5 bg-dostyq-header-stripe" />
       </div>
 
       {/* Mobile Menu */}


### PR DESCRIPTION
## Summary
- wrap the header content in a centered max-w-7xl container so it lines up with the cards
- enlarge the logo and refine responsive spacing while keeping the desktop and mobile menus intact
- update the mobile menu panel with matching padding, accessibility hooks, and hover transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2d0106f28832c859cc6627955812a