### PR TITLE
Align partners marquee duration with CSS

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -6,12 +6,12 @@ const AboutSection = () => {
         
         <div className="max-w-4xl mx-auto">
           <p className="text-dostyq-text text-lg mb-12 leading-relaxed">
-            DostyqTV - это современный казахстанский телеканал, который предлагает качественный 
-            контент для всей семьи. Мы транслируем лучшие фильмы, сериалы и телепередачи, 
+            DostyqTV - это современный казахстанский телеканал, который предлагает качественный
+            контент для всей семьи. Мы транслируем лучшие фильмы, сериалы и телепередачи,
             поддерживая традиции и культуру Евразии.
           </p>
-          
-          <div className="w-full max-w-4xl h-96 bg-dostyq-card rounded-2xl flex items-center justify-center mx-auto relative overflow-hidden">
+
+          <div className="relative w-full aspect-video bg-dostyq-card rounded-2xl shadow-xl mx-auto overflow-hidden">
             <iframe
               width="100%"
               height="100%"
@@ -21,7 +21,7 @@ const AboutSection = () => {
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               referrerPolicy="strict-origin-when-cross-origin"
               allowFullScreen
-              className="rounded-2xl"
+              className="absolute inset-0 h-full w-full"
             ></iframe>
           </div>
         </div>

--- a/src/components/PartnersCarousel.tsx
+++ b/src/components/PartnersCarousel.tsx
@@ -1,9 +1,3 @@
-import type { CSSProperties } from 'react';
-
-const marqueeStyle: CSSProperties & { '--marquee-duration'?: string } = {
-  '--marquee-duration': '12s',
-};
-
 const PartnersCarousel = () => {
   const partners = [
     'Телеканал Казахстан',
@@ -22,7 +16,19 @@ const PartnersCarousel = () => {
         <h2 className="section-title mb-12">Наши партнеры</h2>
         
         <div className="h-30 overflow-hidden relative">
-          <div className="flex items-center space-x-16 marquee" style={marqueeStyle}>
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 w-24 z-10"
+            style={{
+              background: 'linear-gradient(90deg, hsl(var(--dostyq-header-footer-bg)) 0%, hsla(var(--dostyq-header-footer-bg) / 0) 100%)',
+            }}
+          />
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 w-24 z-10"
+            style={{
+              background: 'linear-gradient(270deg, hsl(var(--dostyq-header-footer-bg)) 0%, hsla(var(--dostyq-header-footer-bg) / 0) 100%)',
+            }}
+          />
+          <div className="flex items-center space-x-16 marquee">
             {[...partners, ...partners, ...partners].map((partner, index) => (
               <div
                 key={`${partner}-${index}`}

--- a/src/components/PartnersCarousel.tsx
+++ b/src/components/PartnersCarousel.tsx
@@ -16,24 +16,13 @@ const PartnersCarousel = () => {
         <h2 className="section-title mb-12">Наши партнеры</h2>
         
         <div className="h-30 overflow-hidden relative">
-          <div
-            className="pointer-events-none absolute inset-y-0 left-0 w-24 z-10"
-            style={{
-              background: 'linear-gradient(90deg, hsl(var(--dostyq-header-footer-bg)) 0%, hsla(var(--dostyq-header-footer-bg) / 0) 100%)',
-            }}
-          />
-          <div
-            className="pointer-events-none absolute inset-y-0 right-0 w-24 z-10"
-            style={{
-              background: 'linear-gradient(270deg, hsl(var(--dostyq-header-footer-bg)) 0%, hsla(var(--dostyq-header-footer-bg) / 0) 100%)',
-            }}
-          />
+          <div className="carousel-fade-left" />
+          <div className="carousel-fade-right" />
           <div className="flex items-center space-x-16 marquee">
             {[...partners, ...partners, ...partners].map((partner, index) => (
               <div
                 key={`${partner}-${index}`}
-                className="flex items-center justify-center min-w-[200px] h-12 px-8 bg-dostyq-card rounded-lg"
-                style={{ filter: 'grayscale(1)', opacity: '0.8' }}
+                className="flex items-center justify-center min-w-[200px] h-12 px-8 bg-dostyq-card rounded-lg grayscale opacity-80"
               >
                 <span className="text-dostyq-text font-semibold text-sm whitespace-nowrap">
                   {partner}

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,24 @@
     box-shadow: var(--shadow-glow);
   }
 
+  .carousel-fade-left {
+    @apply pointer-events-none absolute inset-y-0 left-0 w-24 z-10;
+    background: linear-gradient(
+      90deg,
+      hsl(var(--dostyq-header-footer-bg)) 0%,
+      hsla(var(--dostyq-header-footer-bg) / 0) 100%
+    );
+  }
+
+  .carousel-fade-right {
+    @apply pointer-events-none absolute inset-y-0 right-0 w-24 z-10;
+    background: linear-gradient(
+      270deg,
+      hsl(var(--dostyq-header-footer-bg)) 0%,
+      hsla(var(--dostyq-header-footer-bg) / 0) 100%
+    );
+  }
+
   /* Carousel Animation */
   @keyframes marquee {
     0% {

--- a/src/index.css
+++ b/src/index.css
@@ -138,7 +138,7 @@
   /* Carousel Animation */
   @keyframes marquee {
     0% {
-      transform: translateX(100%);
+      transform: translateX(0);
     }
     100% {
       transform: translateX(-100%);


### PR DESCRIPTION
## Summary
- remove the redundant inline marquee duration override in `PartnersCarousel`
- start the marquee animation at `translateX(0)` so the first partner tile is visible immediately while continuing to scroll right-to-left

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d2d0c2b0a4832c8ebe2f3400650430