### PR TITLE
refactor: redesign header navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,26 +9,27 @@ const Header = () => {
 
   return (
     <>
-      <header className="bg-dostyq-header-footer">
+      <header className="bg-[hsla(var(--dostyq-header-footer-bg)/0.85)] backdrop-blur-xl">
         <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
           <div className="flex items-center gap-3">
-            <img src={logo} alt="Dostyq TV Logo" className="h-16 w-auto flex-shrink-0" />
+            <img src={logo} alt="Dostyq TV Logo" className="h-16 w-auto flex-shrink-0 drop-shadow-lg" />
             <span className="sr-only">Dostyq TV</span>
           </div>
 
           {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center gap-2" aria-label="Основное меню">
+          <nav
+            className="hidden md:flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-1 py-1 backdrop-blur-xl shadow-lg shadow-black/20"
+            aria-label="Основное меню"
+          >
             {menuItems.map((item) => (
               <button
                 key={item}
                 onClick={() => setActiveMenu(item)}
                 type="button"
                 aria-current={activeMenu === item ? 'page' : undefined}
-                className={`px-4 py-2 rounded-lg font-semibold transition-all duration-200 hover:brightness-110 ${
-                  activeMenu === item ? 'menu-btn-active' : 'menu-btn-inactive'
-                }`}
+                className={`menu-btn-shared ${activeMenu === item ? 'menu-btn-active' : 'menu-btn-inactive'}`}
               >
-                {item}
+                <span className="relative z-10">{item}</span>
               </button>
             ))}
           </nav>
@@ -47,14 +48,14 @@ const Header = () => {
         </div>
       </header>
 
-      {/* Header Stripe */}
+      {/* Header Divider */}
       <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="h-1.5 bg-dostyq-header-stripe" />
+        <div className="h-px bg-white/15" />
       </div>
 
       {/* Mobile Menu */}
       {mobileMenuOpen && (
-        <div className="md:hidden bg-dostyq-header-footer shadow-lg">
+        <div className="md:hidden bg-dostyq-header-footer/90 backdrop-blur-xl shadow-2xl shadow-black/40">
           <div className="mx-auto w-full max-w-7xl px-4 pb-6 pt-4 sm:px-6 lg:px-8">
             <nav id="mobile-navigation" className="flex flex-col gap-2" aria-label="Мобильное меню">
               {menuItems.map((item) => (
@@ -65,9 +66,7 @@ const Header = () => {
                     setMobileMenuOpen(false);
                   }}
                   type="button"
-                  className={`px-4 py-2 rounded-lg font-semibold transition-all duration-200 text-left hover:brightness-110 ${
-                    activeMenu === item ? 'menu-btn-active' : 'menu-btn-inactive'
-                  }`}
+                  className={`menu-btn-mobile ${activeMenu === item ? 'menu-btn-active' : 'menu-btn-inactive'}`}
                 >
                   {item}
                 </button>

--- a/src/index.css
+++ b/src/index.css
@@ -144,7 +144,8 @@
   }
 
   .menu-btn-mobile {
-    @apply w-full rounded-2xl px-5 py-3 text-left text-base font-semibold transition-all duration-300;
+    @apply w-full rounded-2xl px-5 py-3 text-left text-base font-semibold;
+    transition: var(--transition-smooth);
     background: hsla(var(--dostyq-text-primary) / 0.05);
     color: hsla(var(--dostyq-text-primary) / 0.75);
   }

--- a/src/index.css
+++ b/src/index.css
@@ -100,14 +100,59 @@
   }
 
   /* Menu Button Styles */
+  .menu-btn-shared {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.625rem 1.25rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: var(--transition-smooth);
+    overflow: hidden;
+  }
+
   .menu-btn-active {
-    background-color: hsl(var(--dostyq-menu-btn-active-bg));
-    color: hsl(var(--dostyq-menu-btn-active-text));
+    background: linear-gradient(135deg, hsl(var(--dostyq-menu-btn-active-bg)), hsl(var(--dostyq-text-primary)));
+    color: hsl(var(--dostyq-header-footer-bg));
+    box-shadow: 0 10px 30px hsla(var(--dostyq-menu-btn-active-text) / 0.3);
   }
 
   .menu-btn-inactive {
-    background-color: hsl(var(--dostyq-menu-btn-inactive-bg));
-    color: hsl(var(--dostyq-menu-btn-inactive-text));
+    color: hsla(var(--dostyq-text-primary) / 0.7);
+  }
+
+  .menu-btn-inactive::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: hsla(var(--dostyq-text-primary) / 0.08);
+    opacity: 0;
+    transition: var(--transition-smooth);
+  }
+
+  .menu-btn-inactive:hover {
+    color: hsl(var(--dostyq-text-primary));
+  }
+
+  .menu-btn-inactive:hover::after {
+    opacity: 1;
+  }
+
+  .menu-btn-mobile {
+    @apply w-full rounded-2xl px-5 py-3 text-left text-base font-semibold transition-all duration-300;
+    background: hsla(var(--dostyq-text-primary) / 0.05);
+    color: hsla(var(--dostyq-text-primary) / 0.75);
+  }
+
+  .menu-btn-mobile:hover {
+    background: hsla(var(--dostyq-text-primary) / 0.1);
+    color: hsl(var(--dostyq-text-primary));
+    transform: translateX(4px);
   }
 
   /* Section Titles */


### PR DESCRIPTION
## Summary
- restyle the header with a translucent backdrop and updated divider for a modern feel
- rebuild desktop and mobile navigation buttons with minimalist pill styling and refined hover states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d436119c8c832c9d9077e07d462e8c